### PR TITLE
Display height with a fixed single decimal place

### DIFF
--- a/com.lordzeel.upsy-sd.sdPlugin/includes/upsyActions.js
+++ b/com.lordzeel.upsy-sd.sdPlugin/includes/upsyActions.js
@@ -71,7 +71,7 @@ class ShowHeightAction extends UpsyAction(PassiveAction) {
 	}
 
 	get heightString() {
-		return `${this.height} ${this.units}`;
+		return `${this.height.toFixed(1)} ${this.units}`;
 	}
 
 	get prefix() {


### PR DESCRIPTION
With my UpLift desk, I was getting floating-point type noise in the height value, which was making the display unreadable.